### PR TITLE
fix Loader type to match kong

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -9,14 +9,14 @@ import (
 )
 
 // Loader is a Kong configuration loader for YAML.
-func Loader(r io.Reader) (kong.ResolverFunc, error) {
+func Loader(r io.Reader) (kong.Resolver, error) {
 	decoder := yaml.NewDecoder(r)
 	config := map[interface{}]interface{}{}
 	err := decoder.Decode(config)
 	if err != nil {
 		return nil, err
 	}
-	return func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+	return kong.ResolverFunc(func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
 		// Build a string path up to this flag.
 		path := []string{}
 		for n := parent.Node(); n != nil && n.Type != kong.ApplicationNode; n = n.Parent {
@@ -25,7 +25,7 @@ func Loader(r io.Reader) (kong.ResolverFunc, error) {
 		path = append(path, flag.Name)
 		path = strings.Split(strings.Join(path, "-"), "-")
 		return find(config, path), nil
-	}, nil
+	}), nil
 }
 
 func find(config map[interface{}]interface{}, path []string) interface{} {


### PR DESCRIPTION
The v0.1.0 release seems to have broken compat with latest kong, because `kongyaml.Loader` changed its return type and doesn't match what is expected by `kong.Configuration` anymore. Cf.: 
- `type ConfigurationLoader func(r io.Reader) (Resolver, error)` (before v0.1.0)
- `type ConfigurationLoader func(r io.Reader) (ResolverFunc, error)` (v0.1.0 :boom: )

This small PR should fix that discrepancy.