### PR TITLE
improve handling of map[string]string

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,6 @@ linters:
 linters-settings:
   govet:
     check-shadowing: true
-  gocyclo:
-    min-complexity: 10
   dupl:
     threshold: 100
   goconst:

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -19,6 +19,7 @@ func TestLoader(t *testing.T) {
 			One string
 			Two bool
 		} `embed:"" prefix:"embed-"`
+		Dict map[string]string
 	}
 	var cli CLI
 	r := strings.NewReader(`
@@ -34,6 +35,8 @@ command:
     nested-flag: "nested flag"
     number: 1.0
     int: 12342345234534
+dict:
+    foo: bar
 `)
 	resolver, err := Loader(r)
 	require.NoError(t, err)
@@ -53,6 +56,9 @@ command:
 		}{
 			One: "str",
 			Two: true,
+		},
+		Dict: map[string]string{
+			"foo": "bar",
 		},
 	}
 	require.Equal(t, expected, cli)


### PR DESCRIPTION
This small PR partially fixes #5 by special casing `map[string]interface{}`.

It allows defining your config like:
```go
var cli struct {
	Map   map[string]string
}
```  

Still not working :x: : 
```go
var cli struct {
	Map   map[string]OtherType
}
```

PTAL and let me know if you think there's an elegant way to also deal with the second case.