### PR TITLE
Add YAMLFileMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
-# A Kong configuration loader for YAML [![](https://godoc.org/github.com/alecthomas/kong-yaml?status.svg)](http://godoc.org/github.com/alecthomas/kong-yaml) [![CircleCI](https://img.shields.io/circleci/project/github/alecthomas/kong-yaml.svg)](https://circleci.com/gh/alecthomas/kong-yaml)
+# A Kong YAML utilities [![](https://godoc.org/github.com/alecthomas/kong-yaml?status.svg)](http://godoc.org/github.com/alecthomas/kong-yaml) [![CircleCI](https://img.shields.io/circleci/project/github/alecthomas/kong-yaml.svg)](https://circleci.com/gh/alecthomas/kong-yaml)
+
+## Configuration loader
 
 Use it like so:
 
 ```go
 parser, err := kong.New(&cli, kong.Configuration(kongyaml.Loader, "/etc/myapp/config.yaml", "~/.myapp.yaml))
 ```
+
+## YAMLFileMapper
+
+YAMLFileMapper implements kong.MapperValue to decode a YAML file into
+a struct field.
+
+Use it like so:
+
+```go
+var cli struct {
+  Profile Profile `type:"yamlfile"`
+}
+
+func main() {
+  kong.Parse(&cli, kong.NamedMapper("yamlfile", kongyaml.YAMLFileMapper))
+}
+``` 

--- a/mapper.go
+++ b/mapper.go
@@ -1,0 +1,35 @@
+package kongyaml
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/alecthomas/kong"
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLFileMapper implements kong.MapperValue to decode a YAML file into
+// a struct field.
+//
+//    var cli struct {
+//      Profile Profile `type:"yamlfile"`
+//    }
+//
+//    func main() {
+//      kong.Parse(&cli, kong.NamedMapper("yamlfile", YAMLFileMapper))
+//    }
+var YAMLFileMapper = kong.MapperFunc(decodeYAMLFile) //nolint: gochecknoglobals
+
+func decodeYAMLFile(ctx *kong.DecodeContext, target reflect.Value) error {
+	var fname string
+	if err := ctx.Scan.PopValueInto("filename", &fname); err != nil {
+		return err
+	}
+	f, err := os.Open(fname) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint
+
+	return yaml.NewDecoder(f).Decode(target.Addr().Interface())
+}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -1,0 +1,47 @@
+package kongyaml
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+)
+
+type TestSample struct {
+	Name string `yaml:"name"`
+	Game string `yaml:"game"`
+}
+
+func TestYAMLFileMapper(t *testing.T) {
+	var cli struct {
+		Sample TestSample `type:"yamlfile"`
+	}
+	opt := kong.NamedMapper("yamlfile", YAMLFileMapper)
+	parser, err := kong.New(&cli, opt)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"--sample", "testdata/sample.yaml"})
+	require.NoError(t, err)
+
+	want := TestSample{Name: "Lee Sedol", Game: "Go"}
+	require.Equal(t, want, cli.Sample)
+}
+
+func TestYAMLFileMapperErr(t *testing.T) {
+	var cli struct {
+		Sample TestSample `type:"yamlfile"`
+	}
+	opts := []kong.Option{
+		kong.NamedMapper("yamlfile", YAMLFileMapper),
+		kong.Exit(func(int) { fmt.Println("EXIT") }),
+	}
+	parser, err := kong.New(&cli, opts...)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"--sample", "testdata/MISSING_FILE.yaml"})
+	require.Error(t, err)
+
+	_, err = parser.Parse([]string{"--sample"})
+	require.Error(t, err)
+}

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -1,0 +1,2 @@
+name: Lee Sedol
+game: Go


### PR DESCRIPTION
YAMLFileMapper implements kong.MapperValue to decode a YAML file into
a struct field. Sample usage:

	var cli struct {
	  Profile Profile `type:"yamlfile"`
	}

	func main() {
	  kong.Parse(&cli, kong.NamedMapper("yamlfile", kongyaml.YAMLFileMapper))
	}