### PR TITLE
fix: do not error on empty files

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -1,6 +1,7 @@
 package kongyaml
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,7 +15,7 @@ func Loader(r io.Reader) (kong.Resolver, error) {
 	decoder := yaml.NewDecoder(r)
 	config := map[interface{}]interface{}{}
 	err := decoder.Decode(config)
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("YAML config decode error: %w", err)
 	}
 	return kong.ResolverFunc(func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -63,3 +63,21 @@ dict:
 	}
 	require.Equal(t, expected, cli)
 }
+
+func TestEmptyFile(t *testing.T) {
+	type CLI struct {
+		FlagName string
+	}
+	var cli CLI
+	r := strings.NewReader("")
+	resolver, err := Loader(r)
+	require.NoError(t, err)
+	parser, err := kong.New(&cli, kong.Resolvers(resolver))
+	require.NoError(t, err)
+	_, err = parser.Parse([]string{})
+	require.NoError(t, err)
+	expected := CLI{
+		FlagName: "",
+	}
+	require.Equal(t, expected, cli)
+}


### PR DESCRIPTION
An empty YAML file should behave no differently than a file with just a single YAML document separator (`---`). The former passes the `io.EOF` through, the later returns no error.
This PR should work around the following go-yaml issue: go-yaml/yaml#805